### PR TITLE
Prevent parted warnings in script mode

### DIFF
--- a/plugins/modules/parted.py
+++ b/plugins/modules/parted.py
@@ -570,7 +570,7 @@ def parted(script, device, align):
         align_option = ''
 
     if script and not module.check_mode:
-        command = "%s -s -m %s %s -- %s" % (parted_exec, align_option, device, script)
+        command = "%s -s -f -m %s %s -- %s" % (parted_exec, align_option, device, script)
         rc, out, err = module.run_command(command)
 
         if rc != 0:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add automatic answer "fix" when script mode -s is used in parted.

Comments from the project parted :
automatically answer exceptions with "fix" in script mode, which is useful for:
GPT header not including full disk size; 
moving the backup GPT table to the end of the disk;
MAC fix missing partition map entry; 
etc.
see: https://www.mail-archive.com/parted-devel@alioth-lists.debian.net/msg00369.html

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #1653

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
parted

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

juste use -f with -s and resizepart in the same command.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

Before:
When you enhance the drive on the vcenter, and refresh in the OS, the community.general.parted with resize=true hang like that:

Warning: Not all of the space available to /dev/sdx appears to be used, you can fix the GPT to use all of the space (an extra xxxxx blocks) or continue with the current setting? 
Error: Unable to satisfy all constraints on the partition.

After:
the resize is done correctly.

```
